### PR TITLE
README spelling fix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ Once you have a session, you can then publish events.
 
 .. code-block:: python
 
-    from .elsewhere imort user_session
+    from .elsewhere import user_session
 
     # Verbose publish call
     user_session.publish(


### PR DESCRIPTION
`import` was spelled incorrectly. I fixed it.