### PR TITLE
Add rollback method

### DIFF
--- a/bc_events/__init__.py
+++ b/bc_events/__init__.py
@@ -3,4 +3,4 @@ from .session import EventSession
 
 __all__ = ["EventClient", "EventSession"]
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/bc_events/session.py
+++ b/bc_events/session.py
@@ -1,6 +1,11 @@
+import logging
+
 from kwargs_only import kwargs_only
 
 from .event import Event
+
+
+logger = logging.getLogger("bc.events")
 
 
 class EventSession(object):
@@ -53,6 +58,11 @@ class EventSession(object):
         # TODO use a bulk api endpoint once it exists
         for event in self.events:
             event.publish()
+
+    def rollback(self):
+        """Rolls back any events in the queue for this session since the last flush."""
+        logger.warning("Rolling Back Session Events", extra={"context": {"events": self.events}})
+        self.events = []
 
     def _publish(self, topic, data):
         """Internal method for publishing data to a topic

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.2.0
 commit = True
 tag = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ current_version = 0.1.0
 commit = True
 tag = True
 
-[bumpversion:file:bc_logger/__init__.py]
+[bumpversion:file:bc_events/__init__.py]
 
 [wheel]
 universal = 1

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -74,3 +74,15 @@ def test_flush(user_session):
 
     fake_event.publish.assert_called_once()
     another_fake_event.publish.assert_called_once()
+
+
+def test_rollback(user_session):
+
+    fake_event = Mock()
+    another_fake_event = Mock()
+
+    user_session.events = [fake_event, another_fake_event]
+
+    user_session.rollback()
+
+    assert len(user_session.events) == 0


### PR DESCRIPTION
I'm adding a PR to django-britecore with an app and middleware that will set up the client and session.

In working on the middleware, I realized that we need a level of indirection for a "rollback" mechanism. It could just empty the events list itself, but there's a chance we'll tweak those internals later. So I added a simple `rollback` method to the session that clears the events queue after logging them.