### PR TITLE
Jfindley/ch7931/use bulk endpoint in bc events session flush

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,10 @@ wheels/
 pip-log.txt
 pip-delete-this-directory.txt
 
+
+# IDEs
+.idea/*
+
 # Unit test / coverage reports
 htmlcov/
 .tox/

--- a/bc_events/__init__.py
+++ b/bc_events/__init__.py
@@ -3,4 +3,4 @@ from .session import EventSession
 
 __all__ = ["EventClient", "EventSession"]
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/bc_events/client.py
+++ b/bc_events/client.py
@@ -27,6 +27,7 @@ class EventClient(object):
 
         self.api_url = api_url
         self.publish_url = api_url + "/events" if api_url else None
+        self.publish_all_url = self.publish_all_url + "/bulk" if api_url else None
 
         self.service_name = service_name
 

--- a/bc_events/client.py
+++ b/bc_events/client.py
@@ -27,7 +27,7 @@ class EventClient(object):
 
         self.api_url = api_url
         self.publish_url = api_url + "/events" if api_url else None
-        self.publish_all_url = self.publish_all_url + "/bulk" if api_url else None
+        self.publish_all_url = self.publish_url + "/bulk/" if api_url else None
 
         self.service_name = service_name
 

--- a/bc_events/client.py
+++ b/bc_events/client.py
@@ -27,7 +27,7 @@ class EventClient(object):
 
         self.api_url = api_url
         self.publish_url = api_url + "/events" if api_url else None
-        self.publish_all_url = self.publish_url + "/bulk/" if api_url else None
+        self.publish_bulk_url = self.publish_url + "/bulk/" if api_url else None
 
         self.service_name = service_name
 

--- a/bc_events/session.py
+++ b/bc_events/session.py
@@ -57,7 +57,7 @@ class EventSession(object):
         will not send events and don't have to worry about rolling them back.
         """
 
-        self.publish_all(self.events)
+        self.publish_bulk(self.events)
 
     def rollback(self):
         """Rolls back any events in the queue for this session since the last flush."""
@@ -110,7 +110,7 @@ class EventSession(object):
         topic = self.client.get_topic(category, entity, action)
         self._publish(topic, data)
 
-    def publish_all(self, events):
+    def publish_bulk(self, events):
         """Publish all events
 
         Parameters

--- a/bc_events/session.py
+++ b/bc_events/session.py
@@ -124,16 +124,15 @@ class EventSession(object):
             A list of events to publish
         """
 
-        if not self.client.publish_url:
-            return
-
         all_event_data = [event.request_json for event in events]
 
         # Publish up to MAX_BULK_EVENTS events at a time
         for i in range(0, len(all_event_data), MAX_BULK_EVENTS):
             event_data = all_event_data[i : i + MAX_BULK_EVENTS]
             logger.info("Publishing {0} Events".format(len(event_data)), extra={"context": event_data})
-            requests.post(self.client.publish_all_url, json=event_data)
+
+            if self.client.publish_all_url:
+                requests.post(self.client.publish_all_url, json=event_data)
 
     def __getattr__(self, attr_name):
         """Magic handler to allow shortcuts to the `publish` method

--- a/bc_events/session.py
+++ b/bc_events/session.py
@@ -7,7 +7,7 @@ from .event import Event
 
 logger = logging.getLogger("bc.events")
 MAX_BULK_EVENTS = 250
-BULK_EVENT_SINGLE_POST_THRESHOLD = 5
+BULK_EVENT_SINGLE_PUBLISH_THRESHOLD = 5
 
 
 class EventSession(object):
@@ -58,7 +58,7 @@ class EventSession(object):
         """
 
         # If there are less than BULK_EVENT_SINGLE_POST_THRESHOLD events in the queue, publish individually
-        if len(self.events) <= BULK_EVENT_SINGLE_POST_THRESHOLD:
+        if len(self.events) <= BULK_EVENT_SINGLE_PUBLISH_THRESHOLD:
             for event in self.events:
                 event.publish()
         else:

--- a/bc_events/session.py
+++ b/bc_events/session.py
@@ -55,9 +55,8 @@ class EventSession(object):
         will not send events and don't have to worry about rolling them back.
         """
 
-        # TODO use a bulk api endpoint once it exists
-        for event in self.events:
-            event.publish()
+        event_data = [event.request_json for event in self.events]
+        self.publish_all(event_data)
 
     def rollback(self):
         """Rolls back any events in the queue for this session since the last flush."""

--- a/bc_events/session.py
+++ b/bc_events/session.py
@@ -131,8 +131,8 @@ class EventSession(object):
             event_data = all_event_data[i : i + MAX_BULK_EVENTS]
             logger.info("Publishing {0} Events".format(len(event_data)), extra={"context": event_data})
 
-            if self.client.publish_all_url:
-                requests.post(self.client.publish_all_url, json=event_data)
+            if self.client.publish_bulk_url:
+                requests.post(self.client.publish_bulk_url, json=event_data)
 
     def __getattr__(self, attr_name):
         """Magic handler to allow shortcuts to the `publish` method

--- a/bc_events/session.py
+++ b/bc_events/session.py
@@ -133,6 +133,7 @@ class EventSession(object):
         # Publish up to MAX_BULK_EVENTS events at a time
         for i in range(0, len(all_event_data), MAX_BULK_EVENTS):
             event_data = all_event_data[i:i+MAX_BULK_EVENTS]
+            logger.info("Publishing {0} Events".format(len(event_data)), extra={"context": event_data})
             requests.post(self.client.publish_all_url, json=event_data)
 
     def __getattr__(self, attr_name):

--- a/bc_events/session.py
+++ b/bc_events/session.py
@@ -132,7 +132,7 @@ class EventSession(object):
 
         # Publish up to MAX_BULK_EVENTS events at a time
         for i in range(0, len(all_event_data), MAX_BULK_EVENTS):
-            event_data = all_event_data[i:i+MAX_BULK_EVENTS]
+            event_data = all_event_data[i : i + MAX_BULK_EVENTS]
             logger.info("Publishing {0} Events".format(len(event_data)), extra={"context": event_data})
             requests.post(self.client.publish_all_url, json=event_data)
 

--- a/bc_events/session.py
+++ b/bc_events/session.py
@@ -57,7 +57,12 @@ class EventSession(object):
         will not send events and don't have to worry about rolling them back.
         """
 
-        self.publish_bulk(self.events)
+        # If there are less than BULK_EVENT_SINGLE_POST_THRESHOLD events in the queue, publish individually
+        if len(self.events) <= BULK_EVENT_SINGLE_POST_THRESHOLD:
+            for event in self.events:
+                event.publish()
+        else:
+            self.publish_bulk(self.events)
 
     def rollback(self):
         """Rolls back any events in the queue for this session since the last flush."""
@@ -118,12 +123,6 @@ class EventSession(object):
         events : list
             A list of events to publish
         """
-
-        # If there are less than BULK_EVENT_SINGLE_POST_THRESHOLD events in the queue, publish individually
-        if len(self.events) <= BULK_EVENT_SINGLE_POST_THRESHOLD:
-            for event in self.events:
-                event.publish()
-            return
 
         if not self.client.publish_url:
             return

--- a/bc_events/session.py
+++ b/bc_events/session.py
@@ -1,9 +1,9 @@
 import logging
 
+import requests
 from kwargs_only import kwargs_only
 
 from .event import Event
-
 
 logger = logging.getLogger("bc.events")
 
@@ -107,6 +107,21 @@ class EventSession(object):
         category = category or self.client.default_category
         topic = self.client.get_topic(category, entity, action)
         self._publish(topic, data)
+
+    def publish_all(self, events):
+        """Publish all events
+
+        Parameters
+        ----------
+        events : list
+            A list of events to publish
+        """
+
+        if not self.client.publish_url:
+            return
+
+        event_data = [event.request_json for event in events]
+        requests.post(self.client.publish_all_url, json=event_data)
 
     def __getattr__(self, attr_name):
         """Magic handler to allow shortcuts to the `publish` method

--- a/bc_events/session.py
+++ b/bc_events/session.py
@@ -55,8 +55,7 @@ class EventSession(object):
         will not send events and don't have to worry about rolling them back.
         """
 
-        event_data = [event.request_json for event in self.events]
-        self.publish_all(event_data)
+        self.publish_all(self.events)
 
     def rollback(self):
         """Rolls back any events in the queue for this session since the last flush."""

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.0
+current_version = 0.3.0
 commit = True
 tag = True
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,9 +69,20 @@ def created_test_payload():
 
 
 @pytest.fixture
-def requests_mock(request):
+def event_requests_mock(request):
     req_mock = Mock()
     req_patch = patch("bc_events.event.requests", req_mock)
+    req_patch.start()
+
+    request.addfinalizer(req_patch.stop)
+
+    return req_mock
+
+
+@pytest.fixture
+def session_requests_mock(request):
+    req_mock = Mock()
+    req_patch = patch("bc_events.session.requests", req_mock)
     req_patch.start()
 
     request.addfinalizer(req_patch.stop)

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -9,16 +9,16 @@ def event(user_session, created_test_payload):
     return user_session.events[0]
 
 
-def test_publish(event, job_id, requests_mock):
+def test_publish(event, job_id, event_requests_mock):
 
     event.publish()
 
     if event.session.client.api_url:
-        requests_mock.post.assert_called_once_with(
+        event_requests_mock.post.assert_called_once_with(
             event.session.client.publish_url, json=event.request_json, headers={"x-britecore-job-id": job_id}
         )
     else:
-        requests_mock.post.assert_not_called()
+        event_requests_mock.post.assert_not_called()
 
 
 def test_data_validation_failure(event):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -63,7 +63,7 @@ def test_magic_call_incorrect(user_session, created_test_payload):
         user_session.tested_create(created_test_payload)
 
 
-def test_flush(user_session, session_requests_mock):
+def test_flush_few_events(user_session):
 
     fake_event = Mock()
     another_fake_event = Mock()
@@ -72,7 +72,24 @@ def test_flush(user_session, session_requests_mock):
 
     user_session.flush()
 
+    fake_event.publish.assert_called_once()
+    another_fake_event.publish.assert_called_once()
+
+
+def test_flush_max_events(user_session, session_requests_mock):
+    user_session.events = [Mock()] * 250
+
+    user_session.flush()
+
     assert session_requests_mock.post.call_count == 1 or user_session.client.publish_url is None
+
+
+def test_flush_more_than_max_events(user_session, session_requests_mock):
+    user_session.events = [Mock()] * 250 * 2
+
+    user_session.flush()
+
+    assert session_requests_mock.post.call_count == 2 or user_session.client.publish_url is None
 
 
 def test_rollback(user_session):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -81,7 +81,7 @@ def test_flush_max_events(user_session, session_requests_mock):
 
     user_session.flush()
 
-    assert session_requests_mock.post.call_count == 1 or user_session.client.publish_url is None
+    assert session_requests_mock.post.call_count == 1 or user_session.client.publish_bulk_url is None
 
 
 def test_flush_more_than_max_events(user_session, session_requests_mock):
@@ -89,7 +89,7 @@ def test_flush_more_than_max_events(user_session, session_requests_mock):
 
     user_session.flush()
 
-    assert session_requests_mock.post.call_count == 3 or user_session.client.publish_url is None
+    assert session_requests_mock.post.call_count == 3 or user_session.client.publish_bulk_url is None
 
 
 def test_rollback(user_session):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -21,14 +21,14 @@ def test_publish_delayed(user_session, created_test_payload):
     assert event.data == created_test_payload
 
 
-def test_publish_immediately(immediate_session, created_test_payload, requests_mock):
+def test_publish_immediately(immediate_session, created_test_payload, event_requests_mock):
 
     immediate_session.publish(action="Created", entity="Test", data=created_test_payload)
 
     assert len(immediate_session.events) == 0
 
     if immediate_session.client.api_url:
-        requests_mock.post.assert_called_once()
+        event_requests_mock.post.assert_called_once()
 
 
 def test_publish_no_kwargs(user_session, created_test_payload):
@@ -63,7 +63,7 @@ def test_magic_call_incorrect(user_session, created_test_payload):
         user_session.tested_create(created_test_payload)
 
 
-def test_flush(user_session):
+def test_flush(user_session, session_requests_mock):
 
     fake_event = Mock()
     another_fake_event = Mock()
@@ -72,8 +72,7 @@ def test_flush(user_session):
 
     user_session.flush()
 
-    fake_event.publish.assert_called_once()
-    another_fake_event.publish.assert_called_once()
+    assert session_requests_mock.post.call_count == 1 or user_session.client.publish_url is None
 
 
 def test_rollback(user_session):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -85,11 +85,11 @@ def test_flush_max_events(user_session, session_requests_mock):
 
 
 def test_flush_more_than_max_events(user_session, session_requests_mock):
-    user_session.events = [Mock()] * 250 * 2
+    user_session.events = [Mock()] * (250 * 2 + 100)
 
     user_session.flush()
 
-    assert session_requests_mock.post.call_count == 2 or user_session.client.publish_url is None
+    assert session_requests_mock.post.call_count == 3 or user_session.client.publish_url is None
 
 
 def test_rollback(user_session):


### PR DESCRIPTION
Added a publish_all method that takes a list of events and publishes them via the bulk API
Modified flush to use the new publish_all method