### PR TITLE
Jfindley/ch8101/improve retry logic in bc events client

### DIFF
--- a/bc_events/__init__.py
+++ b/bc_events/__init__.py
@@ -3,4 +3,4 @@ from .session import EventSession
 
 __all__ = ["EventClient", "EventSession"]
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/bc_events/event.py
+++ b/bc_events/event.py
@@ -3,7 +3,7 @@ import logging
 import jsonschema
 
 from .constants import EVENT_SCHEMA
-from .utils import EventsApiWrapper
+from .utils import EventsApiRetryingWrapper
 
 logger = logging.getLogger("bc.events")
 
@@ -76,5 +76,5 @@ class Event(object):
         # TODO this is going to need authentication when BriteAuth is hooked up to the API
         if self.session.client.publish_url:
             headers = {"x-britecore-job-id": self.session.job_id}
-            events_api = EventsApiWrapper(self.session.client.publish_url, request_json, headers=headers)
+            events_api = EventsApiRetryingWrapper(self.session.client.publish_url, request_json, headers=headers)
             events_api.invoke()

--- a/bc_events/event.py
+++ b/bc_events/event.py
@@ -3,7 +3,7 @@ import logging
 import jsonschema
 
 from .constants import EVENT_SCHEMA
-from .utils import requests_session
+from .utils import EventsApiWrapper
 
 logger = logging.getLogger("bc.events")
 
@@ -76,5 +76,5 @@ class Event(object):
         # TODO this is going to need authentication when BriteAuth is hooked up to the API
         if self.session.client.publish_url:
             headers = {"x-britecore-job-id": self.session.job_id}
-            session = requests_session()
-            session.post(self.session.client.publish_url, json=request_json, headers=headers)
+            events_api = EventsApiWrapper(self.session.client.publish_url, request_json, headers=headers)
+            events_api.invoke()

--- a/bc_events/session.py
+++ b/bc_events/session.py
@@ -3,7 +3,7 @@ import logging
 from kwargs_only import kwargs_only
 
 from .event import Event
-from .utils import EventsApiWrapper
+from .utils import EventsApiRetryingWrapper
 
 logger = logging.getLogger("bc.events")
 MAX_BULK_EVENTS = 250
@@ -132,7 +132,7 @@ class EventSession(object):
             logger.info("Publishing {0} Events".format(len(event_data)), extra={"context": event_data})
 
             if self.client.publish_bulk_url:
-                bulk_api = EventsApiWrapper(self.client.publish_bulk_url, event_data)
+                bulk_api = EventsApiRetryingWrapper(self.client.publish_bulk_url, event_data)
                 bulk_api.invoke()
 
     def __getattr__(self, attr_name):

--- a/bc_events/session.py
+++ b/bc_events/session.py
@@ -3,7 +3,7 @@ import logging
 from kwargs_only import kwargs_only
 
 from .event import Event
-from .utils import requests_session
+from .utils import EventsApiWrapper
 
 logger = logging.getLogger("bc.events")
 MAX_BULK_EVENTS = 250
@@ -132,8 +132,8 @@ class EventSession(object):
             logger.info("Publishing {0} Events".format(len(event_data)), extra={"context": event_data})
 
             if self.client.publish_bulk_url:
-                session = requests_session()
-                session.post(self.client.publish_bulk_url, json=event_data)
+                bulk_api = EventsApiWrapper(self.client.publish_bulk_url, event_data)
+                bulk_api.invoke()
 
     def __getattr__(self, attr_name):
         """Magic handler to allow shortcuts to the `publish` method

--- a/bc_events/utils.py
+++ b/bc_events/utils.py
@@ -30,7 +30,7 @@ def build_topic_name(category, entity, action):
     return "{category}.{entity}{action}".format(category=category, entity=entity, action=action)
 
 
-class EventsApiWrapper(object):
+class EventsApiRetryingWrapper(object):
     def __init__(self, url, payload, headers={}, delay=0.45, max_delay=5, max_time=35):
         self.url = url
         self.payload = payload

--- a/bc_events/utils.py
+++ b/bc_events/utils.py
@@ -76,9 +76,9 @@ class EventsApiRetryingWrapper(object):
 
     def invoke(self):
         retryer = Retrying(
-            retry=retry_if_exception_type(requests.exceptions.Timeout) |
-                  retry_if_exception_type(requests.exceptions.ConnectionError) |
-                  retry_if_result(self.retry_if_we_need_to),
+            retry=retry_if_exception_type(requests.exceptions.Timeout)
+            | retry_if_exception_type(requests.exceptions.ConnectionError)
+            | retry_if_result(self.retry_if_we_need_to),
             stop=stop_after_delay(self.max_time),
             wait=wait_exponential(multiplier=self.delay, max=self.max_delay),
         )

--- a/bc_events/utils.py
+++ b/bc_events/utils.py
@@ -29,7 +29,7 @@ def build_topic_name(category, entity, action):
 
 
 class EventsApiRetryingWrapper(object):
-    def __init__(self, url, payload, headers={}, delay=0.45, max_delay=5, max_time=35):
+    def __init__(self, url, payload, headers={}, delay=0.1, max_delay=0.5, max_time=2):
         self.url = url
         self.payload = payload
         self.headers = headers

--- a/bc_events/utils.py
+++ b/bc_events/utils.py
@@ -1,6 +1,11 @@
+import logging
+
 import requests
 from requests.adapters import HTTPAdapter
+from tenacity import Retrying, retry_if_exception_type, retry_if_result, stop_after_delay, wait_exponential
 from urllib3.util.retry import Retry
+
+logger = logging.getLogger("bc.events")
 
 
 def build_topic_name(category, entity, action):
@@ -25,12 +30,58 @@ def build_topic_name(category, entity, action):
     return "{category}.{entity}{action}".format(category=category, entity=entity, action=action)
 
 
-def requests_session():
-    """For use on AWS APIs that periodically fail with 500 and suggest retrying"""
+class EventsApiWrapper(object):
+    def __init__(self, url, payload, headers={}, delay=0.45, max_delay=5, max_time=35):
+        self.url = url
+        self.payload = payload
+        self.headers = headers
+        self.response = None
+        self.errors_we_can_retry = ["ProvisionedThroughputExceededException", "InternalFailureException"]
+        self.delay = delay
+        self.max_delay = max_delay
+        self.max_time = max_time
 
-    session = requests.Session()
-    retry = Retry(total=3, read=3, connect=3, status_forcelist=[500], backoff_factor=0.3, method_whitelist=False)
-    adapter = HTTPAdapter(max_retries=retry)
-    session.mount("https://", adapter)
-    session.mount("http://", adapter)
-    return session
+    def post(self):
+        return requests.post(self.url, json=self.payload, headers=self.headers)
+
+    def extract_failed_record(self, pair):
+        record, result = pair
+        if result in self.errors_we_can_retry:
+            return record
+
+    def retry_if_we_need_to(self, response):
+        response_json = response.json()
+
+        if response.status_code in [400, 500]:
+            if response_json["errorType"] in self.errors_we_can_retry:
+                # The API itself failed, retry the same payload
+                logger.warning(f"Request failed. Retrying this request: {response_json}")
+                return True
+
+            # The API itself failed, but not with an error we should retry
+            logger.warning(f"Unable to retry this request: {response_json}")
+            return False
+
+        if response_json.get("failedRecords", 0) == 0:
+            # No failures, don't retry
+            return False
+
+        # There were partial failures, the payload to retry with should only contain failed records
+        self.payload = [
+            record
+            for record in map(self.extract_failed_record, zip(self.payload, response_json["records"]))
+            if record is not None
+        ]
+
+        logger.warning(f"Partial failures. Retrying {len(self.payload)} records.")
+        return True
+
+    def invoke(self):
+        retryer = Retrying(
+            retry=retry_if_exception_type(requests.exceptions.Timeout) |
+                  retry_if_exception_type(requests.exceptions.ConnectionError) |
+                  retry_if_result(self.retry_if_we_need_to),
+            stop=stop_after_delay(self.max_time),
+            wait=wait_exponential(multiplier=self.delay, max=self.max_delay),
+        )
+        return retryer(self.post)

--- a/bc_events/utils.py
+++ b/bc_events/utils.py
@@ -1,9 +1,7 @@
 import logging
 
 import requests
-from requests.adapters import HTTPAdapter
 from tenacity import Retrying, retry_if_exception_type, retry_if_result, stop_after_delay, wait_exponential
-from urllib3.util.retry import Retry
 
 logger = logging.getLogger("bc.events")
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,3 +2,4 @@ jsonschema>=2.0.0,<3.0.0
 kwargs-only>=1.0.0,<2.0.0
 PyYAML>=3.0.0,<4.0.0
 requests>=2.0.0,<3.0.0
+tenacity==5.0.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0
+current_version = 0.4.0
 commit = True
 tag = True
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import requests
 import yaml
 
 from bc_events import EventClient
-from bc_events.utils import EventsApiWrapper
+from bc_events.utils import EventsApiRetryingWrapper
 
 
 @pytest.fixture(params=["https://fake-site.britecore.com", None])
@@ -73,7 +73,7 @@ def created_test_payload():
 @pytest.fixture
 def events_api_wrapper_invoke_mock(monkeypatch):
     mock = Mock()
-    monkeypatch.setattr(EventsApiWrapper, "invoke", mock)
+    monkeypatch.setattr(EventsApiRetryingWrapper, "invoke", mock)
     return mock
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,6 +80,7 @@ def events_api_wrapper_invoke_mock(monkeypatch):
 @pytest.fixture
 def post_mock(monkeypatch):
     from collections import namedtuple
+
     post_mock = Mock()
     post_mock.return_value = namedtuple("Struct", ["json", "status_code"])(lambda: {}, 201)
     monkeypatch.setattr(requests, "post", post_mock)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import requests
 import yaml
 
 from bc_events import EventClient
+from bc_events.utils import EventsApiWrapper
 
 
 @pytest.fixture(params=["https://fake-site.britecore.com", None])
@@ -70,8 +71,16 @@ def created_test_payload():
 
 
 @pytest.fixture
-def requests_session_mock(monkeypatch):
+def events_api_wrapper_invoke_mock(monkeypatch):
     mock = Mock()
-    mock.post = Mock()
-    monkeypatch.setattr(requests, "Session", mock)
-    return mock()
+    monkeypatch.setattr(EventsApiWrapper, "invoke", mock)
+    return mock
+
+
+@pytest.fixture
+def post_mock(monkeypatch):
+    from collections import namedtuple
+    post_mock = Mock()
+    post_mock.return_value = namedtuple("Struct", ["json", "status_code"])(lambda: {}, 201)
+    monkeypatch.setattr(requests, "post", post_mock)
+    return post_mock

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -9,14 +9,14 @@ def event(user_session, created_test_payload):
     return user_session.events[0]
 
 
-def test_publish(event, job_id, requests_session_mock):
+def test_publish(event, job_id, post_mock):
     event.publish()
     if event.session.client.api_url:
-        requests_session_mock.post.assert_called_once_with(
+        post_mock.assert_called_once_with(
             event.session.client.publish_url, json=event.request_json, headers={"x-britecore-job-id": job_id}
         )
     else:
-        requests_session_mock.post.assert_not_called()
+        post_mock.assert_not_called()
 
 
 def test_data_validation_failure(event):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -21,14 +21,14 @@ def test_publish_delayed(user_session, created_test_payload):
     assert event.data == created_test_payload
 
 
-def test_publish_immediately(immediate_session, created_test_payload, requests_session_mock):
+def test_publish_immediately(immediate_session, created_test_payload, events_api_wrapper_invoke_mock):
 
     immediate_session.publish(action="Created", entity="Test", data=created_test_payload)
 
     assert len(immediate_session.events) == 0
 
     if immediate_session.client.api_url:
-        requests_session_mock.post.assert_called_once()
+        events_api_wrapper_invoke_mock.assert_called_once()
 
 
 def test_publish_no_kwargs(user_session, created_test_payload):
@@ -76,21 +76,21 @@ def test_flush_few_events(user_session):
     another_fake_event.publish.assert_called_once()
 
 
-def test_flush_max_events(user_session, requests_session_mock):
+def test_flush_max_events(user_session, events_api_wrapper_invoke_mock):
     mock = Mock()
     user_session.events = [mock] * 250
 
     user_session.flush()
 
-    assert requests_session_mock.post.call_count == 1 or user_session.client.publish_bulk_url is None
+    assert events_api_wrapper_invoke_mock.call_count == 1 or user_session.client.publish_bulk_url is None
 
 
-def test_flush_more_than_max_events(user_session, requests_session_mock):
+def test_flush_more_than_max_events(user_session, events_api_wrapper_invoke_mock):
     user_session.events = [Mock()] * (250 * 2 + 100)
 
     user_session.flush()
 
-    assert requests_session_mock.post.call_count == 3 or user_session.client.publish_bulk_url is None
+    assert events_api_wrapper_invoke_mock.call_count == 3 or user_session.client.publish_bulk_url is None
 
 
 def test_rollback(user_session):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,198 @@
+from collections import namedtuple
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+from bc_events.utils import EventsApiWrapper
+
+single_event = {
+    "action": "Create",
+    "category": "testing",
+    "entity": "TestEntity",
+    "data": {"message": "BULK PASSED"},
+    "actor": {"id": "bulk-pass-test", "type": "service"},
+}
+
+bulk_events = [single_event] * 4
+
+
+class MultiResponse:
+
+    def __init__(self, responses):
+        self.responses = responses
+        self.status_code = None
+
+    def __getattribute__(self, key):
+        if key == "responses":
+            return super().__getattribute__("responses")
+        elif key == "status_code":
+            return super().__getattribute__("status_code")
+        elif key == "json":
+            response, status_code = self.responses.pop(0)
+            self.status_code = status_code
+            return lambda: response
+
+
+@pytest.fixture(
+    params=[
+        ("https://some_url.com/events/", single_event, {"x-britecore-job-id", "1234567"}),
+        ("https://some_url.com/events/bulk/", bulk_events, {}),
+    ]
+)
+def events_api_wrapper(request):
+    params = request.param
+    return EventsApiWrapper(params[0], params[1], params[2], delay=0.01, max_delay=0.1, max_time=1)
+
+
+def test_post(events_api_wrapper, monkeypatch):
+    post_mock = Mock()
+    monkeypatch.setattr(requests, "post", post_mock)
+    events_api_wrapper.post()
+    assert post_mock.call_count in [1, 4]
+
+
+def test_extract_failed_record(events_api_wrapper):
+
+    # A successful result will be ignored
+    sample1 = (single_event, "Success")
+    result = events_api_wrapper.extract_failed_record(sample1)
+    assert result is None
+
+    # ProvisionedThroughputExceededException will be retried
+    sample2 = (single_event, "ProvisionedThroughputExceededException")
+    result = events_api_wrapper.extract_failed_record(sample2)
+    assert result == single_event
+
+    # InternalFailureException will be retried
+    sample3 = (single_event, "InternalFailureException")
+    result = events_api_wrapper.extract_failed_record(sample3)
+    assert result == single_event
+
+    # Anything else will not be retried
+    sample4 = (single_event, "UnsupportedError")
+    result = events_api_wrapper.extract_failed_record(sample4)
+    assert result is None
+
+
+def test_retry_if_we_need_to_on_400_provisioned_throughput_exceeded(events_api_wrapper):
+    sample_response = namedtuple("Struct", ["json", "status_code"])(
+        lambda: {"errorType": "ProvisionedThroughputExceededException"}, 400
+    )
+    response = events_api_wrapper.retry_if_we_need_to(sample_response)
+
+    # We need to retry this
+    assert response is True
+
+
+def test_retry_if_we_need_to_on_500_internal_failure(events_api_wrapper):
+    sample_response = namedtuple("Struct", ["json", "status_code"])(
+        lambda: {"errorType": "InternalFailureException"}, 500
+    )
+    response = events_api_wrapper.retry_if_we_need_to(sample_response)
+
+    # We need to retry this
+    assert response is True
+
+
+def test_retry_if_we_need_to_on_400_unsupported_failure(events_api_wrapper):
+    sample_response = namedtuple("Struct", ["json", "status_code"])(
+        lambda: {"errorType": "SomethingWeCantRetryException"}, 400
+    )
+    response = events_api_wrapper.retry_if_we_need_to(sample_response)
+
+    # We can't retry this
+    assert response is False
+
+
+def test_retry_if_we_need_to_on_all_events_succeeded(events_api_wrapper):
+    sample_response = namedtuple("Struct", ["json", "status_code"])(
+        lambda: {"failedRecords": 0}, 201
+    )
+    response = events_api_wrapper.retry_if_we_need_to(sample_response)
+
+    # We don't need to retry this
+    assert response is False
+
+
+def test_retry_if_we_need_to_on_partial_failure(events_api_wrapper):
+    sample_response = namedtuple("Struct", ["json", "status_code"])(
+        lambda: {"failedRecords": 1, "records": [
+            single_event,
+            single_event,
+            single_event,
+            single_event,
+            single_event,
+        ]}, 201
+    )
+    response = events_api_wrapper.retry_if_we_need_to(sample_response)
+
+    # We'll retry anything that needs to be retried
+    assert response is True
+
+
+def test_invoke_successful_call(events_api_wrapper, monkeypatch):
+    requests_mock = Mock()
+    requests_mock.return_value = namedtuple("Struct", ["json", "status_code"])(
+        lambda: {"failedRecords": 0, "records": [single_event]}, 201
+    )
+    monkeypatch.setattr(requests, "post", requests_mock)
+    events_api_wrapper.invoke()
+    assert requests_mock.call_count == 1
+
+
+def test_invoke_with_bulk_retries(events_api_wrapper, monkeypatch):
+    responses = [
+        ({"failedRecords": 2, "records": ["Success", "ProvisionedThroughputExceededException", "InternalFailureException"]}, 201),
+        ({"failedRecords": 2, "records": ["ProvisionedThroughputExceededException", "InternalFailureException"]}, 201),
+        ({"failedRecords": 2, "records": ["ProvisionedThroughputExceededException", "InternalFailureException"]}, 201),
+        ({"failedRecords": 0, "records": ["Success", "Success"]}, 201),
+    ]
+    requests_mock = Mock()
+    requests_mock.return_value = MultiResponse(responses)
+    monkeypatch.setattr(requests, "post", requests_mock)
+
+    events_api_wrapper.invoke()
+    assert requests_mock.call_count == 4
+
+
+def test_invoke_without_bulk_retries(events_api_wrapper, monkeypatch):
+    responses = [
+        ({"failedRecords": 0, "records": ["Success", "Success"]}, 201)
+    ]
+
+    requests_mock = Mock()
+    requests_mock.return_value = MultiResponse(responses)
+    monkeypatch.setattr(requests, "post", requests_mock)
+
+    events_api_wrapper.invoke()
+    assert requests_mock.call_count == 1
+
+
+def test_invoke_with_events_retries(events_api_wrapper, monkeypatch):
+    responses = [
+        ({"errorType": "ProvisionedThroughputExceededException"}, 400),
+        ({"errorType": "InternalFailureException"}, 500),
+        ({"errorType": "ProvisionedThroughputExceededException"}, 400),
+        ({"eventId": "some_id", "jobId": "some_job"}, 201)
+    ]
+
+    requests_mock = Mock()
+    requests_mock.return_value = MultiResponse(responses)
+    monkeypatch.setattr(requests, "post", requests_mock)
+
+    events_api_wrapper.invoke()
+    assert requests_mock.call_count == 4
+
+
+def test_invoke_without_events_retries(events_api_wrapper, monkeypatch):
+    responses = [
+        ({"eventId": "some_id", "jobId": "some_job"}, 201)
+    ]
+
+    requests_mock = Mock()
+    requests_mock.return_value = MultiResponse(responses)
+    monkeypatch.setattr(requests, "post", requests_mock)
+
+    events_api_wrapper.invoke()
+    assert requests_mock.call_count == 1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 import pytest
 import requests
 
-from bc_events.utils import EventsApiWrapper
+from bc_events.utils import EventsApiRetryingWrapper
 
 single_event = {
     "action": "Create",
@@ -42,7 +42,7 @@ class MultiResponse:
 )
 def events_api_wrapper(request):
     params = request.param
-    return EventsApiWrapper(params[0], params[1], params[2], delay=0.01, max_delay=0.1, max_time=1)
+    return EventsApiRetryingWrapper(params[0], params[1], params[2], delay=0.01, max_delay=0.1, max_time=1)
 
 
 def test_post(events_api_wrapper, monkeypatch):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,7 +18,6 @@ bulk_events = [single_event] * 4
 
 
 class MultiResponse:
-
     def __init__(self, responses):
         self.responses = responses
         self.status_code = None
@@ -110,13 +109,9 @@ def test_retry_if_we_need_to_on_all_events_succeeded(events_api_wrapper):
 
 
 def test_retry_if_we_need_to_on_partial_failure(events_api_wrapper):
-    sample_response = create_sample_response({"failedRecords": 1, "records": [
-            single_event,
-            single_event,
-            single_event,
-            single_event,
-            single_event,
-        ]}, 201)
+    sample_response = create_sample_response(
+        {"failedRecords": 1, "records": [single_event, single_event, single_event, single_event, single_event]}, 201
+    )
     response = events_api_wrapper.retry_if_we_need_to(sample_response)
 
     # We'll retry anything that needs to be retried
@@ -133,7 +128,13 @@ def test_invoke_successful_call(events_api_wrapper, monkeypatch):
 
 def test_invoke_with_bulk_retries(events_api_wrapper, monkeypatch):
     responses = [
-        ({"failedRecords": 2, "records": ["Success", "ProvisionedThroughputExceededException", "InternalFailureException"]}, 201),
+        (
+            {
+                "failedRecords": 2,
+                "records": ["Success", "ProvisionedThroughputExceededException", "InternalFailureException"],
+            },
+            201,
+        ),
         ({"failedRecords": 2, "records": ["ProvisionedThroughputExceededException", "InternalFailureException"]}, 201),
         ({"failedRecords": 2, "records": ["ProvisionedThroughputExceededException", "InternalFailureException"]}, 201),
         ({"failedRecords": 0, "records": ["Success", "Success"]}, 201),
@@ -147,9 +148,7 @@ def test_invoke_with_bulk_retries(events_api_wrapper, monkeypatch):
 
 
 def test_invoke_without_bulk_retries(events_api_wrapper, monkeypatch):
-    responses = [
-        ({"failedRecords": 0, "records": ["Success", "Success"]}, 201)
-    ]
+    responses = [({"failedRecords": 0, "records": ["Success", "Success"]}, 201)]
 
     requests_mock = Mock()
     requests_mock.return_value = MultiResponse(responses)
@@ -164,7 +163,7 @@ def test_invoke_with_events_retries(events_api_wrapper, monkeypatch):
         ({"errorType": "ProvisionedThroughputExceededException"}, 400),
         ({"errorType": "InternalFailureException"}, 500),
         ({"errorType": "ProvisionedThroughputExceededException"}, 400),
-        ({"eventId": "some_id", "jobId": "some_job"}, 201)
+        ({"eventId": "some_id", "jobId": "some_job"}, 201),
     ]
 
     requests_mock = Mock()
@@ -176,9 +175,7 @@ def test_invoke_with_events_retries(events_api_wrapper, monkeypatch):
 
 
 def test_invoke_without_events_retries(events_api_wrapper, monkeypatch):
-    responses = [
-        ({"eventId": "some_id", "jobId": "some_job"}, 201)
-    ]
+    responses = [({"eventId": "some_id", "jobId": "some_job"}, 201)]
 
     requests_mock = Mock()
     requests_mock.return_value = MultiResponse(responses)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -46,9 +46,7 @@ def events_api_wrapper(request):
     return EventsApiRetryingWrapper(params[0], params[1], params[2], delay=0.01, max_delay=0.1, max_time=1)
 
 
-def test_post(events_api_wrapper, monkeypatch):
-    post_mock = Mock()
-    monkeypatch.setattr(requests, "post", post_mock)
+def test_post(events_api_wrapper, post_mock):
     events_api_wrapper.post()
     assert post_mock.call_count in [1, 4]
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,10 +24,8 @@ class MultiResponse:
         self.status_code = None
 
     def __getattribute__(self, key):
-        if key == "responses":
-            return super().__getattribute__("responses")
-        elif key == "status_code":
-            return super().__getattribute__("status_code")
+        if key in ["responses", "status_code"]:
+            return super().__getattribute__(key)
         elif key == "json":
             response, status_code = self.responses.pop(0)
             self.status_code = status_code


### PR DESCRIPTION
Now when invoking the regular /events/ API, 

If the request is successful -> success
If the request fails with 400 ProvisionedThroughputExceededException -> retry until success or 35 seconds
If the request fails with 500 InternalFailureException -> retry until success or 35 seconds
If the request fails for any other reason -> fail

When invoking the /events/bulk/ API,

If the request is successful -> success
If the request fails with 400 ProvisionedThroughputExceededException -> retry until success or 35 seconds
If the request fails with 500 InternalFailureException -> retry until success or 35 seconds
If the request fails for any other reason -> fail
If failedRecords is > 0 -> retry any failed records if they failed because of ProvisionedThroughputExceededException or InternalFailureException