### PR TITLE
Log event topic when published

### DIFF
--- a/bc_events/__init__.py
+++ b/bc_events/__init__.py
@@ -3,4 +3,4 @@ from .session import EventSession
 
 __all__ = ["EventClient", "EventSession"]
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/bc_events/event.py
+++ b/bc_events/event.py
@@ -44,7 +44,7 @@ class Event(object):
         }
 
     def __str__(self):
-        return self.topic_name
+        return str(self.topic)
 
     def __repr__(self):
         return "Event(topic=%r, data=%r, session=%r)" % (self.topic, self.data, self.session)
@@ -71,7 +71,7 @@ class Event(object):
         self.validate()
 
         request_json = self.request_json
-        logger.info("Publishing Event", extra={"context": request_json})
+        logger.info("Publishing event {}".format(self), extra={"context": request_json})
 
         # TODO this is going to need authentication when BriteAuth is hooked up to the API
         if self.session.client.publish_url:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.0
+current_version = 0.4.1
 commit = True
 tag = True
 

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -19,6 +19,10 @@ def test_publish(event, job_id, post_mock):
         post_mock.assert_not_called()
 
 
+def test_str(event):
+    assert str(event) == "testing.TestCreated"
+
+
 def test_data_validation_failure(event):
 
     event.data = {"bad": "payload"}


### PR DESCRIPTION
This PR logs the event topic when an event is published. Logs now show as `Publishing event lines.FieldCreated` rather than `Publishing Event`.

I also fixed a bug where `str(event)` would not work because `topic_name` was not an attribute on Event.